### PR TITLE
ViewMorePage Based on Files Instead of Students

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -14,7 +14,7 @@ import SignUp from "./pages/SignUp";
 import Landing from "./pages/Landing";
 import DownloadReportPage from "./pages/DownloadReportPage";
 //import FederatedOAuth from "./components/FederatedOAuth";
-import { getUser } from "./client/API";
+import { getUser, getZipFile } from "./client/API";
 
 function App() {
   let defaultRoute = "LogIn";
@@ -36,15 +36,17 @@ function App() {
   };
 
   const getCurrentRoute = () => {
-    if (userObject && (currentRoute == "LogIn" || currentRoute == "SignUp")) {
+    if (userObject && (currentRoute === "LogIn" || currentRoute === "SignUp")) {
       setCurrentRoute("main");
     } else if (
       !userObject &&
-      currentRoute != "LogIn" &&
-      currentRoute != "SignUp"
+      currentRoute !== "LogIn" &&
+      currentRoute !== "SignUp"
     ) {
       setCurrentRoute("LogIn");
     }
+
+    console.log(currentZipFileId);
 
     if (currentZipFileId !== "undefined") {
       return (

--- a/client/src/components/ChartsPage.js
+++ b/client/src/components/ChartsPage.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Radar, Pie, Line, Bar, getElementAtEvent } from "react-chartjs-2";
 import GaugeChart from "react-gauge-chart";
-import { Card, List } from "semantic-ui-react";
+import { Card, CardContent, List } from "semantic-ui-react";
 import {
   Chart as ChartJS,
   RadialLinearScale,
@@ -111,26 +111,24 @@ function getLineData(xArray, yArray) {
   };
 }
 
-function getErrors(students) {
+function getErrors(files) {
   var errorList = [];
-  students.map((student) =>
-    student.Files.map((file) => {
-      if (file.Errors) {
-        file.Errors.map((error) => {
-          if (error.ErrorType.Severity !== 0) {
-            errorList.push(error);
-          }
-        });
-      }
-      if (file.PyErrors) {
-        file.PyErrors.map((error) => {
-          if (error.ErrorType.Severity !== 0) {
-            errorList.push(error);
-          }
-        });
-      }
-    })
-  );
+  files.map((file) => {
+    if (file.Errors) {
+      file.Errors.map((error) => {
+        if (error.ErrorType.Severity !== 0) {
+          errorList.push(error);
+        }
+      });
+    }
+    if (file.PyErrors) {
+      file.PyErrors.map((error) => {
+        if (error.ErrorType.Severity !== 0) {
+          errorList.push(error);
+        }
+      });
+    }
+  });
   return errorList;
 }
 
@@ -149,17 +147,17 @@ function getStandardDeviation(array) {
 
 // Used by ViewMorePage.js
 function ChartsPage(props) {
-  // get list of errors from all students in zip - TODO: ALL FILES, NOT STUDENTS
-  const errorList = getErrors(props.file.Students);
+  // get list of errors from all files in zip 
+  const errorList = getErrors(props.zipfile.Files);
 
   // get frequency of all vulnerabilities in zip file - TODO: THIS MIGHT BE GOOD TO KEEP?
   var freqOfVuln = new Array(10).fill(0);
   errorList.forEach((error) => freqOfVuln[error.ErrorType.Severity - 1]++);
 
-  // get frequency of severities for each student - TODO: PROB DON'T KEEP
+  // get frequency of severities for each file - TODO: PROB DON'T KEEP
   var freqOfSev = new Array(10).fill(0);
-  props.file.Students.forEach(
-    (student) => freqOfSev[student.SeverityScore - 1]++
+  props.zipfile.Files.forEach(
+    (file) => freqOfSev[file.SeverityScore - 1]++
   );
 
   // get most popular vulnerabilities
@@ -183,11 +181,12 @@ function ChartsPage(props) {
     <Card.Group>
       <Card>
         <Card.Header>Overall Zip File Severity</Card.Header>
+        <CardContent>FIX GAUGE</CardContent>
         <Card.Content>
           <GaugeChart
             id="gauge-chart1"
             nrOfLevels={9}
-            percent={props.file.SeverityScore / 10}
+            percent={props.zipfile.SeverityScore / 10}
             textColor="#345243"
             needleColor="#8A948F"
             formatTextValue={(value) => value / 10}
@@ -195,23 +194,24 @@ function ChartsPage(props) {
         </Card.Content>
       </Card>
       <Card>
-        <Card.Header>Students with Highest Severity Score</Card.Header>
+        <Card.Header>Files with Highest Severity Score</Card.Header>
         <Card.Content>
           <List>
-            {props.file.Students.sort(
+            {props.zipfile.Files.sort(
               (a, b) => b.SeverityScore - a.SeverityScore
             )
               .slice(0, 5)
-              .map((student) => (
+              .map((file) => (
                 <List.Item>
-                  {student.Name}: {student.SeverityScore.toString()}
+                  {file.Name}: {file.SeverityScore.toString()}
                 </List.Item>
               ))}
           </List>
         </Card.Content>
       </Card>
       <Card>
-        <Card.Header>Severity Scores of All Students</Card.Header>
+        <Card.Header>Severity Scores of All Files</Card.Header>
+        <Card.Content>To Do: Files can have any severity, not just 0-10</Card.Content>
         <Card.Content>
           <Pie data={getPieData(freqOfSev)} />
         </Card.Content>
@@ -229,24 +229,10 @@ function ChartsPage(props) {
         </Card.Content>
       </Card>
       <Card>
-        <Card.Header>Frequency of Severities in All Files</Card.Header>
+        <Card.Header>Vulnerabilities by Language</Card.Header>
         <Card.Content>
+          TODO
           <Radar data={getRadarData(freqOfVuln)} />
-        </Card.Content>
-      </Card>
-      <Card>
-        <Card.Header>Frequency of Severities in All Files</Card.Header>
-        <Card.Content>
-          <Bar data={getBarData(freqOfVuln)} />
-        </Card.Content>
-        <Card.Content>
-          <List>
-            <List.Item>Mean: {getMean(severityList).toFixed(2)}</List.Item>
-            <List.Item>
-              Standard Deviation:{" "}
-              {getStandardDeviation(severityList).toFixed(2)}
-            </List.Item>
-          </List>
         </Card.Content>
       </Card>
     </Card.Group>
@@ -282,6 +268,7 @@ function ZipChartsPage(props) {
     <Card.Group>
       <Card>
         <Card.Header>Average Severity Score of All Zip Files</Card.Header>
+        <CardContent>FIX GAUGE</CardContent>
         <Card.Content>
           <GaugeChart
             id="gauge-chart2"
@@ -310,10 +297,12 @@ function ZipChartsPage(props) {
       </Card>
       <Card>
         <Card.Header>Severity Scores of All Zip Files</Card.Header>
+        <CardContent>TODO: Why doesn't it appear?</CardContent>
         <Pie data={getPieData(freqOfVuln)} />
       </Card>
       <Card>
         <Card.Header>Severity Scores Over Time</Card.Header>
+        <CardContent>Change size to be longer</CardContent>
         <Line data={getLineData(zipDate, zipSev)} />
       </Card>
     </Card.Group>

--- a/client/src/components/ChartsPage.js
+++ b/client/src/components/ChartsPage.js
@@ -47,7 +47,8 @@ function getRadarData(dataArray) {
   };
 }
 
-function getPieData(dataArray) {
+// need a set color function which returns n random colors for n entries in map
+function getPieData(dataArray) { // change input to mapOfSeverities
   return {
     labels: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
     datasets: [
@@ -155,10 +156,23 @@ function ChartsPage(props) {
   errorList.forEach((error) => freqOfVuln[error.ErrorType.Severity - 1]++);
 
   // get frequency of severities for each file - TODO: PROB DON'T KEEP
+  var freqOfSev = new Map();
+  props.zipfile.Files.forEach(
+    (file) => {
+      if (freqOfSev.has(file.SeverityScore)) {
+        freqOfSev.set(file.SeverityScore, freqOfSev.get(file.SeverityScore) + 1)
+      }
+      else {
+        freqOfSev.set(file.SeverityScore, 1)
+      }
+    }
+  )
+
+  /*
   var freqOfSev = new Array(10).fill(0);
   props.zipfile.Files.forEach(
     (file) => freqOfSev[file.SeverityScore - 1]++
-  );
+  );*/
 
   // get most popular vulnerabilities
   var vulns = new Map();
@@ -211,7 +225,7 @@ function ChartsPage(props) {
       </Card>
       <Card>
         <Card.Header>Severity Scores of All Files</Card.Header>
-        <Card.Content>To Do: Files can have any severity, not just 0-10</Card.Content>
+        <Card.Content>To Do: Files can have any severity, not just 0-10; Doesn't appear b/c input is now a map but expects array.</Card.Content>
         <Card.Content>
           <Pie data={getPieData(freqOfSev)} />
         </Card.Content>
@@ -297,7 +311,7 @@ function ZipChartsPage(props) {
       </Card>
       <Card>
         <Card.Header>Severity Scores of All Zip Files</Card.Header>
-        <CardContent>TODO: Why doesn't it appear?</CardContent>
+        <CardContent>TODO: Doesn't appear b/c zero is not an option - need to support variable labels/severities</CardContent>
         <Pie data={getPieData(freqOfVuln)} />
       </Card>
       <Card>

--- a/client/src/pages/ViewMorePage.js
+++ b/client/src/pages/ViewMorePage.js
@@ -26,6 +26,36 @@ props: id={currentZipFileId}
           updateZipFileHandler={setCurrentZipFileId}
 */
 
+// Can access zip file by id and all is viewable
+function ViewMorePage(props) {
+	const { id, updateRouteHandler, updateZipFileHandler } = props;
+	const [file, setFile] = useState({ Students: [] });
+
+	console.log(id);
+
+	useEffect(async () => {
+		const results = (await getZipFile(id)).data;
+		console.log(results);
+		setFile(results);
+	}, []);
+
+	return (
+		<Grid style={{ padding: "3.5vw" }}>
+			<Grid.Row>
+				<Grid.Column textAlign="right">
+					<Card>
+						<Card.Content>
+							<h1>Here's a card.</h1>
+							<p>{id}</p>
+						</Card.Content>
+					</Card>
+				</Grid.Column>
+			</Grid.Row>
+		</Grid>
+	)
+}
+
+/*
 function ViewMorePage(props) {
 	const { id, updateRouteHandler, updateZipFileHandler } = props;
 	const [file, setFile] = useState({ Students: [] });
@@ -87,12 +117,6 @@ function ViewMorePage(props) {
 										<Card.Meta>
 											Submitted {student.Files.length} files
 										</Card.Meta>
-										{/* <Card.Meta>Submitted 20 files</Card.Meta> */}
-										{/* <Card.Meta>Submitted 20 files</Card.Meta> */}
-										{/* <Card.Description textAlign="center">
-								<Statistic label="detections" value={"4"} />
-								<Statistic label="severity score" value={"9"} />
-							</Card.Description> */}
 									</Card.Content>
 									<Card.Content extra>
 										<Icon color={"blue"} name="user" />
@@ -362,6 +386,6 @@ function ViewMorePage(props) {
 			</Grid.Row>
 		</Grid>
 	);
-}
+} */
 
 export default ViewMorePage;

--- a/client/src/pages/ViewMorePage.js
+++ b/client/src/pages/ViewMorePage.js
@@ -1,67 +1,37 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
 import {
 	Grid,
 	Card,
 	Modal,
-	Form,
 	List,
 	Button,
 	Image,
 	Header,
 	Input,
-	Segment,
 	Statistic,
-	Dropdown,
 	Icon,
 	Tab,
 } from "semantic-ui-react";
-import moment from "moment";
 import { getZipFile } from "../client/API.js";
 import { ChartsPage } from "../components/ChartsPage";
 
-/*
-props: id={currentZipFileId}
-          updateRouteHandler={setCurrentRoute}
-          updateZipFileHandler={setCurrentZipFileId}
-*/
-
-// Can access zip file by id and all is viewable
 function ViewMorePage(props) {
 	const { id, updateRouteHandler, updateZipFileHandler } = props;
-	const [file, setFile] = useState({ Students: [] });
+	const [zipfile, setZipFile] = useState({ Files: [] });
+	const [open, setOpen] = useState(false);
+	const [errors, setErrors] = useState([]);
+	const [fileNameFilter, setFileNameFilter] = useState("");
 
 	console.log(id);
 
-	useEffect(async () => {
-		const results = (await getZipFile(id)).data;
-		console.log(results);
-		setFile(results);
-	}, []);
-
-	return (
-		<Grid style={{ padding: "3.5vw" }}>
-			<Grid.Row>
-				<Grid.Column textAlign="right">
-					<Card>
-						<Card.Content>
-							<h1>Here's a card.</h1>
-							<p>{id}</p>
-						</Card.Content>
-					</Card>
-				</Grid.Column>
-			</Grid.Row>
-		</Grid>
-	)
-}
-
-/*
-function ViewMorePage(props) {
-	const { id, updateRouteHandler, updateZipFileHandler } = props;
-	const [file, setFile] = useState({ Students: [] });
-	const [open, setOpen] = useState(false);
-	const [errors, setErrors] = useState([]);
-	const [studentNameFilter, setStudentNameFilter] = useState("");
+	useEffect(() => {
+		async function fetchZipFileData() {
+		  const response = (await getZipFile(id)).data; 
+		  console.log(response);
+		  setZipFile(response);
+		}
+		fetchZipFileData();
+	}, [id]); 
 
 	function getColor(value) {
 		//value from 0 to 1
@@ -70,42 +40,36 @@ function ViewMorePage(props) {
 		return ["hsl(", hue, ",100%,50%)"].join("");
 	}
 
-	useEffect(async () => {
-		const results = (await getZipFile(id)).data;
-		setFile(results);
-	}, []);
-
-	const getStudents = () => {
-		let filteredStudents = [...file.Students];
-		if (studentNameFilter !== "") {
-			filteredStudents = filteredStudents.filter((student) =>
-				student.Name.startsWith(studentNameFilter)
+	const getFiles = () => {
+		let filteredFiles = [...zipfile.Files];
+		if (fileNameFilter !== "") {
+			filteredFiles = filteredFiles.filter((file) =>
+				file.Name.startsWith(fileNameFilter)
 			);
 		}
-		return filteredStudents;
+		return filteredFiles;
 	};
-
 
 	const panes = [
 		{
-			menuItem: "Students",
+			menuItem: "Files",
 			render: () => (
 				<Grid>
 					<Grid.Row>
-					<Grid.Column style={{ width: "80%" }}>
-						<Input
-							style={{ width: "100%" }}
-							placeholder="Search for student"
-							onChange={(e) => setStudentNameFilter(e.target.value)}
-						/>
-					</Grid.Column>
-					<Grid.Column>
-						<Button icon="sort"></Button>
-					</Grid.Column>
+						<Grid.Column style={{ width: "80%" }}>
+							<Input
+								style={{ width: "100%" }}
+								placeholder="Search for File"
+								onChange={(e) => setFileNameFilter(e.target.value)}
+							/>
+						</Grid.Column>
+						<Grid.Column>
+							<Button icon="sort"></Button>
+						</Grid.Column>
 					</Grid.Row>
 					<Grid.Row>
 						<Card.Group>
-							{getStudents().map((student) => (
+							{getFiles().map((file) => (
 								<Card>
 									<Card.Content>
 										<Image
@@ -113,71 +77,58 @@ function ViewMorePage(props) {
 											size="mini"
 											src="https://i.ibb.co/vxd7Rwc/abc-123-programmer-software-developer-generated.jpg"
 										/>
-										<Card.Header>{student.Name}</Card.Header>
-										<Card.Meta>
-											Submitted {student.Files.length} files
-										</Card.Meta>
+										<Card.Header>{file.Name}</Card.Header>
 									</Card.Content>
 									<Card.Content extra>
 										<Icon color={"blue"} name="user" />
 										<span style={{ color: "blue" }}>
-											{student.Files.reduce(
-												(prev, currFile) =>
-													prev + currFile.ErrorCount,
-												0
-											)}{" "}
+											{file.ErrorCount}{" "}
 											Detections
 										</span>
 									</Card.Content>
 									<Card.Content extra>
 										<Icon
 											style={{
-												color: getColor(student.SeverityScore),
+												color: getColor(file.SeverityScore),
 											}}
 											name="exclamation triangle"
 										/>
 										<span style={{ color: "black" }}>
-											{student.SeverityScore} Severity Score
+											{file.SeverityScore} Severity Score
 										</span>
 									</Card.Content>
 									<Card.Content extra>
 										<div className="ui two buttons">
-											{student.Files.reduce(
-												(prev, currFile) =>
-													prev + currFile.ErrorCount,
-												0
-											) !== 0 ? (
+											{file.ErrorCount !== 0 ? (
 												<Button
 													basic
 													color="primary"
 													onClick={() => {
 														var allErrors = [];
-														student.Files.forEach(
-															(currFile) => {
-																if (currFile.Errors) {
-																	currFile.Errors.forEach(
-																		(error) => {
-																			allErrors.push({
-																				data: error,
-																				fileName: currFile.Name,
-																				type: "JS"
-																			});
-																		}
-																	);
+														console.log(file.Errors);
+														console.log(file.PyErrors);
+														if (file.Errors) {
+															file.Errors.forEach(
+																(error) => {
+																	allErrors.push({
+																		data: error,
+																		fileName: file.Name,
+																		type: "JS"
+																	})
 																}
-																if (currFile.PyErrors) {
-																	currFile.PyErrors.forEach(
-																		(error) => {
-																			allErrors.push({
-																				data: error,
-																				fileName: currFile.Name,
-																				type: "PY"
-																			});
-																		}
-																	);
+															);
+														}
+														if (file.PyErrors) {
+															file.PyErrors.forEach(
+																(error) => {
+																	allErrors.push({
+																		data: error,
+																		fileName: file.Name,
+																		type: "PY"
+																	})
 																}
-															}
-														);
+															);
+														}
 														setErrors(allErrors);
 														setOpen(true);
 													}}
@@ -196,17 +147,8 @@ function ViewMorePage(props) {
 				</Grid>
 			),
 		},
-		{ menuItem: "Graphs", render: () => <ChartsPage file={file} /> },
-	];
-
-	const getDate = (obj) => {
-		obj = obj.substring(0, obj.indexOf("T"));
-		return (
-			obj.substring(obj.indexOf("-") + 1, obj.length) +
-			"-" +
-			obj.substring(0, obj.indexOf("-"))
-		);
-	};
+		{ menuItem: "Graphs", render: () => <ChartsPage file={zipfile} />  } // error - reading undefined map
+	]
 
 	return (
 		<Grid style={{ padding: "3.5vw" }}>
@@ -227,9 +169,9 @@ function ViewMorePage(props) {
 				<Grid columns={2} style={{ paddingRight: "15%" }}>
 					<Grid.Column>
 						<Header as="h1">
-							{file.Name}
+							{zipfile.Name}
 							<Header.Subheader>
-								Ran on {file.Date}
+								Ran on {zipfile.Date}
 							</Header.Subheader>
 						</Header>
 					</Grid.Column>
@@ -242,7 +184,7 @@ function ViewMorePage(props) {
 							<Card.Description textAlign="center">
 								<Statistic
 									label="number of files"
-									value={file.FileCount}
+									value={zipfile.FileCount}
 								/>
 							</Card.Description>
 						</Card.Content>
@@ -252,7 +194,7 @@ function ViewMorePage(props) {
 							<Card.Description textAlign="center">
 								<Statistic
 									label="number of detections"
-									value={file.ErrorCount}
+									value={zipfile.ErrorCount}
 								/>
 							</Card.Description>
 						</Card.Content>
@@ -262,7 +204,7 @@ function ViewMorePage(props) {
 							<Card.Description textAlign="center">
 								<Statistic
 									label="Severity Score"
-									value={file.SeverityScore}
+									value={zipfile.SeverityScore}
 								/>
 							</Card.Description>
 						</Card.Content>
@@ -385,7 +327,8 @@ function ViewMorePage(props) {
 				</Modal>
 			</Grid.Row>
 		</Grid>
-	);
-} */
+		
+	)
+}
 
 export default ViewMorePage;

--- a/client/src/pages/ViewMorePage.js
+++ b/client/src/pages/ViewMorePage.js
@@ -147,7 +147,7 @@ function ViewMorePage(props) {
 				</Grid>
 			),
 		},
-		{ menuItem: "Graphs", render: () => <ChartsPage file={zipfile} />  } // error - reading undefined map
+		{ menuItem: "Graphs", render: () => <ChartsPage zipfile={zipfile} />  } // error - reading undefined map
 	]
 
 	return (


### PR DESCRIPTION
All is now displayable and based on files instead of students. There are a fair number of non-trivial fixes to the metrics that I need to make - I've added contents to the cards to describe what changes need to be made, so you can see what needs to be done for each by visiting the page. I've also added tasks for them to our Trello board. I might not get to them all this sprint what with the presentation and my travel plans, but I should be able to finish them by the first week of Sprint 5.

Note that we'll need to make some changes when PHP is up and running. In a couple places the code tallies up the total errors by checking for JS errors and adding them then checking for PY errors and adding them. We'll need to add another field to the File model for PHP errors, and then I'll do checks and add those errors to the total count. I guess I could have used the isJavaFile and isPyFile to check - I might go back and refactor that after I finish the metrics fixes.